### PR TITLE
Each "Call To Action Page" Gets a <title> which is that Book's Title

### DIFF
--- a/bin/generate_landing_page
+++ b/bin/generate_landing_page
@@ -91,9 +91,14 @@ class GenerateLandingPageScript:
 
                   manifest_as_obj['spine'].append({'type': 'application/html', 'href': 'text/call-to-action.html'})
 
-                  # copy book_dir to...
+                  #  read call-to-action.html as a template and substitute in the Book's title as document title
+                  call_to_action_string = open(os.path.join(package_dir, 'call-to-action.html')).read()
+                  call_to_action_string = call_to_action_string.replace("{{title}}", title)
 
-                  shutil.copy(os.path.join(package_dir, 'call-to-action.html'), os.path.join(book_dir, 'text'))
+                  with codecs.open(os.path.join(book_dir, 'text', 'call-to-action.html'), 'w', 'utf-8') as book_specific_call_to_action_file:
+                    book_specific_call_to_action_file.write(call_to_action_string)
+
+                #   shutil.copy(os.path.join(package_dir, 'call-to-action.html'), os.path.join(book_dir, 'text'))
                   with codecs.open(manifest_path, 'w', 'utf-8') as manifest_file:
                       manifest_file.write(json.dumps(manifest_as_obj))
 

--- a/call-to-action.html
+++ b/call-to-action.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <title>{{title}}</title>
     <meta charset="utf-8">
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsProxyObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
This is a fix for https://github.com/NYPL-Simplified/web-reader-landing-page/issues/11.
I've confirmed that each page will end up with the correctly substituted value in `<title>` but would like @kfriedman to independently verify.

Asking @aslagle to look at to make sure I'm being a good (enough) Python citizen and ensure this won't cause a hiccup in the reader.