### PR TITLE
Fix path to call-to-action.html in manifest.appcache

### DIFF
--- a/bin/generate_landing_page
+++ b/bin/generate_landing_page
@@ -119,7 +119,7 @@ class GenerateLandingPageScript:
                       manifest = manifest_file.read()
 
                   manifest_list = "index.html\n"
-                  manifest_list += "text/call-to-action.html\n"
+                  manifest_list += "call-to-action.html\n"
 
                   for file_to_copy in FILES_TO_COPY:
                       path = os.path.join(package_dir, file_to_copy)


### PR DESCRIPTION
`manifest.appcache` needs to know call-to-action.html's new location in the book's root.