### PR TITLE
Changed GAP cookie to last for 14 weeks

### DIFF
--- a/book_index.html.template
+++ b/book_index.html.template
@@ -17,7 +17,9 @@
     })(window,document,'script','https://api.nypltech.org/api/v0.1/ga-proxy/javascript/gaproxy.js','gap');
 
     gap('init', 'SubwayReads');
-    gap('create', 'UA-1420324-145', 'auto');
+    gap('create', 'UA-1420324-145', {
+      cookieExpires: 60 * 60 * 24 * 7 * 14 // 14 weeks
+    });
     gap('send', 'pageview');
 
     gap('send', 'event', 'ReadBook', 'Start', document.title);

--- a/call-to-action.html
+++ b/call-to-action.html
@@ -10,7 +10,9 @@
       })(window,document,'script','https://api.nypltech.org/api/v0.1/ga-proxy/javascript/gaproxy.js','gap');
 
       gap('init', 'SubwayReads');
-      gap('create', 'UA-1420324-145', 'auto');
+      gap('create', 'UA-1420324-145', {
+        cookieExpires: 60 * 60 * 24 * 7 * 14 // 14 weeks
+      });
       gap('send', 'pageview');
 
       gap('send', 'event', 'ReadBook', 'Finish', document.title);

--- a/index.html.template
+++ b/index.html.template
@@ -15,7 +15,9 @@
      })(window,document,'script','https://api.nypltech.org/api/v0.1/ga-proxy/javascript/gaproxy.js','gap');
 
      gap('init', 'SubwayReads');
-     gap('create', 'UA-1420324-145', 'auto');
+     gap('create', 'UA-1420324-145', {
+       cookieExpires: 60 * 60 * 24 * 7 * 14 // 14 weeks
+     });
      gap('send', 'pageview');
   </script>
 </head>


### PR DESCRIPTION
Based on our meeting, we agreed to track/save patron usage during a 14 week window. This update (and related updates to the Google Analytics Proxy service) makes this possible.