### PR TITLE
Accomodate Plympton Books & Fix Mixed Content Warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 env
+
 output
+
+# A temporary holding area where we download epubs, images
+workspace
+
 *.csv

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 env
 output
+*.csv

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ bin/generate_landing_page <publisher_asset_file_name> <book_spreadsheet> <output
 Follow the instructions at http://docs.aws.amazon.com/cli/latest/userguide/installing.html to install and configure the aws cli.
 
 To upload an output directory to an s3 bucket, run
-<<<<<<< HEAD
 
 `aws s3 cp output s3://bucket-name/ --recursive --acl public-read --cache-control max-age=300 --profile your-aws-cli-profile-name`
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,16 @@ Run `go get -u github.com/NYPL-Simplified/webpub-exporter` to download and build
 * Run `git submodule init && git submodule update` to bring in the web reader.
 
 ## Usage
-bin/generate_landing_page <spreadsheet_file_name> <output_directory>
 
+```bash
+bin/generate_landing_page <publisher_asset_file_name> <book_spreadsheet> <output_directory>
+```
+
+|Argument                     |Description|
+|-----------------------------|           |
+|`<publisher_asset_file_name>`|"Dropbox URLs" sheet from [this spreadsheet](https://docs.google.com/spreadsheets/d/1TNykdmeY2zYOvWRcn46YBrF6ar31ZbLVzZANSoKASNk/edit?ts=58ece1d2#gid=1365026099)|
+|`<spreadsheet_file_name>`    |A files that contains the books, in order (e.g "RS Selections" sheet from [this spreadsheet](https://docs.google.com/spreadsheets/d/1TNykdmeY2zYOvWRcn46YBrF6ar31ZbLVzZANSoKASNk/edit?ts=58ece1d2#gid=0))|
+|`<output_directory>`         |Where to drop off build artifact|
 
 ### Uploading to S3
 

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ bin/generate_landing_page <publisher_asset_file_name> <book_spreadsheet> <output
 Follow the instructions at http://docs.aws.amazon.com/cli/latest/userguide/installing.html to install and configure the aws cli.
 
 To upload an output directory to an s3 bucket, run
-```aws s3 cp output s3://bucket-name/ --recursive --acl public-read --profile your-aws-cli-profile-name```
+
+`aws s3 cp output s3://bucket-name/ --recursive --acl public-read --cache-control max-age=300 --profile your-aws-cli-profile-name`
 
 Note this command is `cp`, not `sync`. This uploads any new or updated files, but does not remove deleted files. Any books that have been removed from the landing page will continue to be available to anyone who has started reading and bookmarked them.
 
 ## License
 
-```
 Copyright © 2016 The New York Public Library, Astor, Lenox, and Tilden Foundations
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/generate_landing_page
+++ b/bin/generate_landing_page
@@ -12,6 +12,7 @@ import urllib2
 import json
 import shutil
 import zipfile
+import uuid
 
 # I am having SSL Cert problems
 import ssl
@@ -95,20 +96,23 @@ class GenerateLandingPageScript:
 
                   # Get the cover, from either the workspace or the internet
                   # and put it in output_dir/covers/originalfilename.ext
-                  local_path_to_cover = ""
 
+                  #This UUID is helpful in cache-busting
+                  book_uuid = str(uuid.uuid4())
+                  local_path_to_cover = os.path.join(self.output_dir, 'covers', book_uuid)
+                  os.makedirs(local_path_to_cover)
                   if "http" in cover or "https" in cover:
                     remote_cover_content = urllib2.urlopen(cover).read()
-                    local_path_to_cover  = os.path.join(self.output_dir, 'covers', os.path.basename(cover))
+                    local_path_to_cover  = os.path.join(local_path_to_cover, os.path.basename(cover))
                     with open(local_path_to_cover, 'w') as local_cover:
                       local_cover.write(remote_cover_content)
                   else:
                     # This cover was extracted in download_and_extract_publisher_assets()
                     workspace_path_to_cover = os.path.join(self.workspace_path, cover)
-                    local_path_to_cover     = os.path.join(self.output_dir, 'covers', cover)
+                    local_path_to_cover     = os.path.join(local_path_to_cover, cover)
                     shutil.copy(workspace_path_to_cover, local_path_to_cover)
 
-                  cover_src = "covers/" + os.path.basename(local_path_to_cover)
+                  cover_src = os.path.join('covers', book_uuid, os.path.basename(local_path_to_cover))
                   download = row.get(EPUB_URL_HEADER)
                   temp_file = ""
 

--- a/bin/generate_landing_page
+++ b/bin/generate_landing_page
@@ -10,6 +10,12 @@ import shutil
 import subprocess
 import urllib2
 import json
+import shutil
+import zipfile
+
+# I am having SSL Cert problems
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
 
 # Header Title Mappings
 SPREADSHEET_TITLE_HEADER    = "Title"
@@ -40,14 +46,20 @@ FILES_TO_COPY = ["index.css",
 
 class GenerateLandingPageScript:
 
-      def __init__(self, csv_file, output_file):
+      def __init__(self, publisher_asset_file, csv_file, output_dir):
+          self.publisher_asset_file = publisher_asset_file
           self.csv_file = csv_file
           self.output_dir = output_dir
+          self.workspace_path = os.path.join(package_dir, "workspace")
 
       def run(self):
+          self.clean_and_create_workspace()
+          self.download_and_extract_publisher_assets()
+
           if not os.path.exists(self.output_dir):
               os.mkdir(self.output_dir)
               os.mkdir(self.output_dir + "/books")
+              os.mkdir(self.output_dir + "/covers")
 
           # Prepare javascript to copy into the book directories later.
           npm_result = subprocess.call("npm install", cwd=os.path.abspath(os.path.join(package_dir, "webpub-viewer")), shell=True)
@@ -56,7 +68,7 @@ class GenerateLandingPageScript:
 
           books_html = []
 
-          with open(csv_file) as file:
+          with open(self.csv_file) as file:
               reader = csv.DictReader(file)
 
               for row in reader:
@@ -68,15 +80,37 @@ class GenerateLandingPageScript:
 
                   author = unicode(row.get(SPREADSHEET_AUTHOR_HEADER), 'utf-8')
                   cover = row.get(COVER_URL_HEADER)
-                  download = row.get(EPUB_URL_HEADER)
 
+                  # Get the cover, from either the workspace or the internet
+                  # and put it in output_dir/covers/originalfilename.ext
+                  local_path_to_cover = ""
+
+                  if "http" in cover or "https" in cover:
+                    remote_cover_content = urllib2.urlopen(cover).read()
+                    local_path_to_cover  = os.path.join(self.output_dir, 'covers', os.path.basename(cover))
+                    with open(local_path_to_cover, 'w') as local_cover:
+                      local_cover.write(remote_cover_content)
+                  else:
+                    # This cover was extracted in download_and_extract_publisher_assets()
+                    workspace_path_to_cover = os.path.join(self.workspace_path, cover)
+                    local_path_to_cover     = os.path.join(self.output_dir, 'covers', cover)
+                    shutil.copy(workspace_path_to_cover, local_path_to_cover)
+
+                  cover_src = "covers/" + os.path.basename(local_path_to_cover)
+                  download = row.get(EPUB_URL_HEADER)
+                  temp_file = ""
                   folder_name = (title + " - " + author).encode('ascii', 'ignore')
-                  print "Downloading %s." % download
-                  remote_epub = urllib2.urlopen(download)
-                  content = remote_epub.read()
-                  temp_file = os.path.abspath(os.path.join(package_dir, "temp.epub"))
-                  with open(temp_file, "w") as local_epub:
-                      local_epub.write(content)
+
+                  if "http" in download or "https" in download:
+                      print "Downloading %s." % download
+                      remote_epub = urllib2.urlopen(download)
+                      content = remote_epub.read()
+                      temp_file = os.path.abspath(os.path.join(package_dir, "temp.epub"))
+                      with open(temp_file, "w") as local_epub:
+                          local_epub.write(content)
+                  else:
+                      print "Looking for %s locally" % download
+                      temp_file = os.path.join(self.workspace_path, download)
 
                   book_dir = os.path.join(self.output_dir, "books/" + folder_name)
                   export_result = subprocess.call('$GOPATH/bin/webpub-exporter -f %s -o "%s"' % (temp_file, book_dir), shell=True)
@@ -98,7 +132,6 @@ class GenerateLandingPageScript:
                   with codecs.open(os.path.join(book_dir, 'call-to-action.html'), 'w', 'utf-8') as book_specific_call_to_action_file:
                     book_specific_call_to_action_file.write(call_to_action_string)
 
-                #   shutil.copy(os.path.join(package_dir, 'call-to-action.html'), os.path.join(book_dir, 'text'))
                   with codecs.open(manifest_path, 'w', 'utf-8') as manifest_file:
                       manifest_file.write(json.dumps(manifest_as_obj))
 
@@ -132,7 +165,7 @@ class GenerateLandingPageScript:
 
                   book_html = """
                   <a href="books/%(folder_name)s/index.html" title="%(title)s" class="%(class)s">
-                    <img src="%(cover)s" alt="%(title)s" />
+                    <img src="%(cover_src)s" alt="%(title)s" />
                     <div class="info">
                       <div class="title">%(title)s</div>
                       <div class="author">%(author)s</div>
@@ -141,7 +174,7 @@ class GenerateLandingPageScript:
                   """ % {
                       "title": title,
                       "author": author,
-                      "cover": cover,
+                      "cover_src": cover_src,
                       "folder_name": folder_name,
                       "class": "adult" if adult else ""
                   }
@@ -171,9 +204,40 @@ class GenerateLandingPageScript:
           with open(os.path.join(self.output_dir, "manifest.appcache"), "w") as output_file:
                 output_file.write(cacheManifest)
 
-if len(sys.argv) < 3:
-   raise Exception("Usage: bin/generate_landing_page <csv_file> <output_dir>")
+      def clean_and_create_workspace(self):
+          if os.path.exists(self.workspace_path):
+            shutil.rmtree(self.workspace_path)
+          print "Creating a fresh workspace"
+          os.mkdir(self.workspace_path)
 
-csv_file = sys.argv[1]
-output_dir = sys.argv[2]
-GenerateLandingPageScript(csv_file, output_dir).run()
+      def download_and_extract_publisher_assets(self):
+          print "Downloading ZIPs from %s" % self.publisher_asset_file
+          with open(self.publisher_asset_file) as file:
+              reader = csv.DictReader(file)
+              for row in reader:
+                  url = row["URL to ZIP containing EPUBs and covers"]
+                  basename = os.path.basename(url)
+
+                  print "downloading %s to workspace" % url
+                  content = urllib2.urlopen(url).read()
+                  zip_path = os.path.join(self.workspace_path, basename+".zip")
+
+                  # write local zip
+                  with open(zip_path, "w") as local_zip:
+                     local_zip.write(content)
+
+                  # defale zip into workspace
+                  print "...extracting"
+                  with zipfile.ZipFile(zip_path,"r") as zip_ref:
+                     zip_ref.extractall(self.workspace_path)
+
+
+if len(sys.argv) != 4:
+   raise Exception("Usage: bin/generate_landing_page <publisher_asset_file_name> <book_spreadsheet> <output_directory>")
+
+publisher_asset_file = sys.argv[1]
+book_csv_file        = sys.argv[2]
+output_dir           = sys.argv[3]
+
+
+GenerateLandingPageScript(publisher_asset_file, book_csv_file, output_dir).run()


### PR DESCRIPTION
Hey @aslagle 

## Mixed Content Problem

Our main/catalog page fills in `image[src]` attributes directly with the values in the "Cover URL" column.
Since our pages will be served over https, and those image URLs are often http - it would trigger
a mixed-content warning in browsers. Not the end of the world, but certainly something we can/should avoid.

## The Plympton Problem

Some books don't link directly to their epubs and cover images in the spreadsheet.

In the past we'd see:

* An "EPUB URL" like "http://somedomain.example.com/ISBN/9781682280294.epub"
* A "Cover URL" like "http://somedomain.example.com/ISBN/9781682280294.png"

Now we'll occasionally see:

* An "EPUB URL" like "9781683604358_The-Musical-Vanity-Boxes.epub".
* A "Cover URL" like "9781683604358_The-Musical-Vanity-Boxes.png"

That is simply a filename, not a URL.
The epubs and images are actually located in one of the .zip file 'o assets that can be found in the "Dropbox URLs" sheet of [this spreadsheet](https://docs.google.com/spreadsheets/d/1TNykdmeY2zYOvWRcn46YBrF6ar31ZbLVzZANSoKASNk/edit?ts=58ece1d2#gid=1365026099)

## The Solution to Both Problems

This branch:

* Now takes path to the "Dropbox" csv as an input.
* Downloads and extracts the .zips into a "workspace" directory
* Conditionally looks on disk or the web for epubs depending on if it looks like a URL.
* Conditionally looks for cover images in workspace or the web if it looks like a URL but ALWAYS moves them into the newly created `./output/covers` directory in our build artifact.
* Always makes `img[src]` attribute the new covers dir. (bye bye mixed-content warning).

The new arguments are described in a schnazzy table in the README.
But an example call (using the assets attached) would be:

```bash
./bin/generate_landing_page publisher_asset_links.csv all.csv output
```

## Going Forward

**This script is very optimisitic and will throw exceptions quickly if an epub is malformed, if an image/epub is missing - I'd like to keep it that way.**

Also - I have an [open issue](https://github.com/NYPL-Simplified/web-reader-landing-page/issues/23)
that describes how we likely want to scale down all images in `output/covers` for the sake of web optimization.

CCing: 

* @EdwinGuzman & @kfriedman since this changes the build command has changed and they're likely to want to build.

* @leonardr - to ensure that I'm using good fixtures...[csvs.zip](https://github.com/NYPL-Simplified/web-reader-landing-page/files/947917/csvs.zip).

