### PR TITLE
:gear: fixes a duplicated id use on our [x] close icon

### DIFF
--- a/images/xIcon.svg
+++ b/images/xIcon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="close-icon" viewBox="0 0 29.69 29.812" preserveAspectRatio="xMidYMid meet" aria-labelledby="close-icon" role="img" class="svgIcon">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29.69 29.812" preserveAspectRatio="xMidYMid meet" aria-labelledby="close-icon" role="img" class="svgIcon">
   <title id="close-icon">Close Icon</title>
   <path d="M2081.71,127.488l26.79-26.879a1.459,1.459,0,0,1,2.06,2.068l-26.79,26.879a1.453,1.453,0,0,1-2.06,0A1.483,1.483,0,0,1,2081.71,127.488Z" transform="translate(-2081.31 -100.188)"/>
   <path d="M2083.77,100.609l26.79,26.879a1.459,1.459,0,0,1-2.06,2.068l-26.79-26.879a1.483,1.483,0,0,1,0-2.068A1.453,1.453,0,0,1,2083.77,100.609Z" transform="translate(-2081.31 -100.188)"/>


### PR DESCRIPTION
we use `aria-labelledby` from the ````title```` id.