### PR TITLE
Share settings across books.

### DIFF
--- a/book_index.html.template
+++ b/book_index.html.template
@@ -35,15 +35,17 @@
       var webpubManifestUrl = new URL("manifest.json", window.location.href);
       var bookCacheUrl = new URL("appcache.html", window.location.href);
 
-      var store = new LocalStorageStore.default(webpubManifestUrl);
+      var store = new LocalStorageStore.default(webpubManifestUrl.href);
       var cacher = new ServiceWorkerCacher.default(store, webpubManifestUrl, "../../sw.js", bookCacheUrl);
 
       var paginator = new ColumnsPaginatedBookView.default();
       var scroller = new ScrollingBookView.default();
       var annotator = new LocalAnnotator.default(store);
+
+      var settingsStore = new LocalStorageStore.default("subway-library");
       var fontSizes = [ 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32 ];
       var defaultFontSize = 16;
-      BookSettings.default.create(store, [paginator, scroller], fontSizes, defaultFontSize).then(function (settings) {
+      BookSettings.default.create(settingsStore, [paginator, scroller], fontSizes, defaultFontSize).then(function (settings) {
         IFrameNavigator.default.create(element, webpubManifestUrl, store, cacher, settings, annotator, paginator, scroller);
       });
     });


### PR DESCRIPTION
This is an update to the reader so it will share settings changes across books. If you change the font size or switch to scrolling view in one book, those settings will also apply to any other books you open.

This also affects downloading for offline use which is a bit weird, but we're planning to take out the controls for that so it won't matter.