### PR TITLE
Sharing links

### DIFF
--- a/about.html.template
+++ b/about.html.template
@@ -1,9 +1,23 @@
 <!DOCTYPE html>
 <html lang="en" manifest="manifest.appcache">
 <head>
-  <title>Subway Reads | About</title>
+  <title>Subway Library | About</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <meta  property="og:type" content="website" />
+  <meta  property="og:site_name" content="Subway Library" />
+  <meta  property="og:title" content="Subway Library | About" />
+  <meta  property="og:image" content="iphone_simplyE.png" />
+  <meta  property="og:description" content="Subway Library | Browse books, excerpts, and short stories from NYC public libraries. Connect to Transit Wireless Wi-Fi at any MTA station to start reading now." />
+  <meta  property="og:url" content="http://subwaylibrary.nyc" />
+  <meta  name="twitter:card" content="summary_large_image" />
+  <meta  name="twitter:site" content="@nypl" />
+  <meta  name="twitter:creator" content="@nypl" />
+  <meta  name="twitter:title" content="Subway Library" />
+  <meta  name="twitter:description" content="Subway Library | Browse books, excerpts, and short stories from NYC public libraries. Connect to Transit Wireless Wi-Fi at any MTA station to start reading now." />
+  <meta  name="twitter:image" content="iphone_simplyE.png" />
+
   <link rel="stylesheet" href="index.min.css" />
   <link rel="icon" href="simplye.png" sizes="300x300" type="image/png"/>
   <!-- Home screen icon in iOS -->
@@ -110,8 +124,8 @@
         </div>
 
         <p>To celebrate cell service and free Wi-Fi in all underground subway stations, NYC’s libraries, MTA, and Transit Wireless have partnered to bring you Subway Library.</p>
-        <p>Simply connect to TransitWireless Wi-Fi in any MTA station. Once you're connected, you can read free books, excerpts, and short stories, all provided by NYC’s public libraries.</p>
-        <p>Subway Library is powered by SimplyE, the free library e-reader app that lets you browse, borrow, and read thousands of library e-books instantly—anywhere, anytime.</p>
+        <p>Simply connect to TransitWireless Wi-Fi in any MTA station. Once you’re connected, you can read free books, excerpts, and short stories, all provided by NYC’s public libraries.</p>
+        <p>Subway Library is powered by SimplyE, the free library e-reader app that lets you browse, borrow, and read thousands more  library e-books instantly—anywhere, anytime.</p>
 
         <h3>SimplyE</h3>
         <img src="iphone_simplyE.png" class="about-simplye" alt="" />

--- a/bin/generate_landing_page
+++ b/bin/generate_landing_page
@@ -204,6 +204,7 @@ class GenerateLandingPageScript:
                           output_file.write(out)
 
                   # For the individual book description pages
+                  socialMediaHTML = socialMedia.replace("{{title}}", title).replace("{{url}}", "/book_desc/" + title + " - " + author + ".html").replace("{{author}}", author)
                   book_desc_dir = os.path.join(self.output_dir, "book_desc/")
                   book_desc_html = """
                       <div class="book-details">
@@ -235,13 +236,14 @@ class GenerateLandingPageScript:
                       "folder_name": folder_name,
                       "description": description,
                       "mta_category": mta_category,
-                      "socialMedia": socialMedia
+                      "socialMedia": socialMediaHTML
                   }
 
                   # Adding individual book titles and descriptions to dictionary to render later
                   all_books_description[title + " - " + author] = {
                       "title": title,
-                      "book_desc_html": book_desc_html
+                      "book_desc_html": book_desc_html,
+                      "cover": "../" + cover_src
                   }
 
                   with open(APP_CACHE_HTML) as appcache_file:
@@ -399,7 +401,7 @@ class GenerateLandingPageScript:
           for book in all_books_description:
               with open(BOOK_DESC_TEMPLATE) as template_file:
                   template = template_file.read()
-                  out = template.replace("{{title}}", all_books_description[book]['title'])
+                  out = template.replace("{{title}}", all_books_description[book]['title']).replace("{{cover}}", all_books_description[book]['cover'])
                   out = out.replace("{{book_desc_html}}", all_books_description[book]['book_desc_html']).replace("{{category_nav}}", "".join(category_nav))
                   out = out.replace("{{logo}}", logo).replace("{{menuOpenBtn}}", menuOpenBtn).replace("{{xIconBtn}}", xIconBtn).replace("{{footerLogos}}", footerLogos)
                   out = out.replace("{{footerSocialMedia}}", footerSocialMedia).replace("{{downloadAppBtns}}", downloadAppBtns)

--- a/book_category.html.template
+++ b/book_category.html.template
@@ -1,9 +1,23 @@
 <!DOCTYPE html>
 <html lang="en" manifest="../manifest.appcache">
 <head>
-  <title>Subway Reads | {{category}}</title>
+  <title>Subway Library | {{category}}</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <meta  property="og:type" content="website" />
+  <meta  property="og:site_name" content="Subway Library" />
+  <meta  property="og:title" content="Subway Library | {{category}}" />
+  <meta  property="og:image" content="iphone_simplyE.png" />
+  <meta  property="og:description" content="Subway Library | Browse books, excerpts, and short stories from NYC public libraries. Connect to Transit Wireless Wi-Fi at any MTA station to start reading now." />
+  <meta  property="og:url" content="http://subwaylibrary.nyc" />
+  <meta  name="twitter:card" content="summary_large_image" />
+  <meta  name="twitter:site" content="@nypl" />
+  <meta  name="twitter:creator" content="@nypl" />
+  <meta  name="twitter:title" content="Subway Library" />
+  <meta  name="twitter:description" content="Subway Library | Browse books, excerpts, and short stories from NYC public libraries. Connect to Transit Wireless Wi-Fi at any MTA station to start reading now." />
+  <meta  name="twitter:image" content="iphone_simplyE.png" />
+
   <link rel="stylesheet" href="../index.min.css" />
   <link rel="icon" href="../simplye.png" sizes="300x300" type="image/png"/>
   <!-- Home screen icon in iOS -->
@@ -62,8 +76,10 @@
         {{callOutText}}
         {{downloadAppBtns}}
         <div class="action-links">
-          <p>Learn more about <a href="#">SimplyE</a>, <a href="#">Queens Library</a>, and
-            <a href="#">Brooklyn Library</a> apps.
+          <p>Learn more about
+            <a href="https://www.nypl.org/books-music-dvds/ebookcentral/simplye">The New York Public Library</a>
+            <a href="https://www.bklynlibrary.org/ebooks">Brooklyn Library</a>
+            <a href="http://connect.queenslibrary.org/">Queens Library</a>
           </p>
         </div>
       </div>

--- a/book_desc.html.template
+++ b/book_desc.html.template
@@ -1,9 +1,23 @@
 <!DOCTYPE html>
 <html lang="en" manifest="../manifest.appcache">
 <head>
-  <title>Subway Reads | {{title}}</title>
+  <title>Subway Library | {{title}}</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <meta  property="og:type" content="website" />
+  <meta  property="og:site_name" content="Subway Library" />
+  <meta  property="og:title" content="Subway Library | {{title}}" />
+  <meta  property="og:image" content="{{cover}}" />
+  <meta  property="og:description" content="Subway Library | Currently reading {{title}}." />
+  <meta  property="og:url" content="http://subwaylibrary.nyc" />
+  <meta  name="twitter:card" content="summary_large_image" />
+  <meta  name="twitter:site" content="@nypl" />
+  <meta  name="twitter:creator" content="@nypl" />
+  <meta  name="twitter:title" content="Subway Library" />
+  <meta  name="twitter:description" content="Subway Library | Currently reading {{title}}." />
+  <meta  name="twitter:image" content="{{cover}}" />
+
   <link rel="stylesheet" href="../index.min.css" />
   <link rel="icon" href="../simplye.png" sizes="300x300" type="image/png"/>
   <!-- Home screen icon in iOS -->
@@ -62,8 +76,10 @@
         {{callOutText}}
         {{downloadAppBtns}}
         <div class="action-links">
-          <p>Learn more about <a href="#">SimplyE</a>, <a href="#">Queens Library</a>, and
-            <a href="#">Brooklyn Library</a> apps.
+          <p>Learn more about
+            <a href="https://www.nypl.org/books-music-dvds/ebookcentral/simplye">The New York Public Library</a>
+            <a href="https://www.bklynlibrary.org/ebooks">Brooklyn Library</a>
+            <a href="http://connect.queenslibrary.org/">Queens Library</a>
           </p>
         </div>
       </div>

--- a/index.html.template
+++ b/index.html.template
@@ -1,9 +1,23 @@
 <!DOCTYPE html>
 <html lang="en" manifest="manifest.appcache">
 <head>
-  <title>Subway Reads</title>
+  <title>Subway Library</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <meta  property="og:type" content="website" />
+  <meta  property="og:site_name" content="Subway Library" />
+  <meta  property="og:title" content="Subway Library" />
+  <meta  property="og:image" content="iphone_simplyE.png" />
+  <meta  property="og:description" content="Subway Library | Browse books, excerpts, and short stories from NYC public libraries. Connect to Transit Wireless Wi-Fi at any MTA station to start reading now." />
+  <meta  property="og:url" content="http://subwaylibrary.nyc" />
+  <meta  name="twitter:card" content="summary_large_image" />
+  <meta  name="twitter:site" content="@nypl" />
+  <meta  name="twitter:creator" content="@nypl" />
+  <meta  name="twitter:title" content="Subway Library" />
+  <meta  name="twitter:description" content="Subway Library | Browse books, excerpts, and short stories from NYC public libraries. Connect to Transit Wireless Wi-Fi at any MTA station to start reading now." />
+  <meta  name="twitter:image" content="iphone_simplyE.png" />
+
   <link rel="stylesheet" href="index.min.css" />
   <link rel="icon" href="simplye.png" sizes="300x300" type="image/png"/>
   <!-- Home screen icon in iOS -->
@@ -43,8 +57,8 @@
 
     <main>
       <div class="banner">
-        <p>Read books, excerpts, and short stories from NYC public libraries.</p>
-        <a href="about.html">Learn more &gt;</a>
+        <p>Browse books, excerpts, and short stories from NYC public libraries. Connect to Transit Wireless Wi-Fi at any MTA station to start reading now.</p>
+        <a href="about.html" aria-label="Learn more about Subway Library">Learn more &gt;</a>
       </div>
 
       <div role="dialog" aria-labelledby="age-check-title" class="age-check" style="display: none">
@@ -68,8 +82,10 @@
         {{callOutText}}
         {{downloadAppBtns}}
         <div class="action-links">
-          <p>Learn more about <a href="#">SimplyE</a>, <a href="#">Queens Library</a>, and
-            <a href="#">Brooklyn Library</a> apps.
+          <p>Learn more about
+            <a href="https://www.nypl.org/books-music-dvds/ebookcentral/simplye">The New York Public Library</a>
+            <a href="https://www.bklynlibrary.org/ebooks">Brooklyn Library</a>
+            <a href="http://connect.queenslibrary.org/">Queens Library</a>
           </p>
         </div>
       </div>

--- a/index.scss
+++ b/index.scss
@@ -140,7 +140,7 @@ main {
 }
 
 .books a {
-  display: table-cell;
+  // display: table-cell;
 }
 .books a .title {
   font-weight: 900;
@@ -155,7 +155,8 @@ main {
   /*display: none;*/
 }
 .books img {
-  width: 120px;
+  // width: 120px;
+  height: 180px;
 }
 .books .info {
   margin-top: 5px;
@@ -347,7 +348,7 @@ nav#global-nav {
 
 /* Homepage */
 .category-lane {
-  margin: 20px 15px 0;
+  margin: 10px 15px 0;
   list-style-type: none;
 }
 .category-header {
@@ -371,7 +372,7 @@ nav#global-nav {
 }
 .lane-container {
   width: 100%;
-  height: 310px;
+  height: 320px;
   overflow: auto;
 }
 
@@ -415,13 +416,13 @@ nav#global-nav {
 
 /* home page */
 .books {
-  display: table;
-  table-layout: fixed;
+  // display: table;
+  // table-layout: fixed;
   width: 100%;
 }
 .books li {
-  width: 120px;
-  height: 120px;
+  // width: 120px;
+  // height: 120px;
   display: table-cell;
   vertical-align: top;
   padding-right: 10px;
@@ -453,9 +454,6 @@ nav#global-nav {
 .call-to-action img {
   width: 100px;
 }
-.call-to-action a {
-  display: inline-block;
-}
 
 .download-link svg {
   width: 150px;
@@ -478,6 +476,8 @@ nav#global-nav {
 .call-to-action .action-links a {
   font-weight: 900;
   text-decoration: underline;
+  display: block;
+  margin-top: 15px;
 }
 
 body.active {

--- a/index.scss
+++ b/index.scss
@@ -139,9 +139,6 @@ main {
   }
 }
 
-.books a {
-  // display: table-cell;
-}
 .books a .title {
   font-weight: 900;
   font-size: 1.2em;
@@ -155,7 +152,6 @@ main {
   /*display: none;*/
 }
 .books img {
-  // width: 120px;
   height: 180px;
 }
 .books .info {
@@ -416,13 +412,9 @@ nav#global-nav {
 
 /* home page */
 .books {
-  // display: table;
-  // table-layout: fixed;
   width: 100%;
 }
 .books li {
-  // width: 120px;
-  // height: 120px;
   display: table-cell;
   vertical-align: top;
   padding-right: 10px;

--- a/templates/bookSocialMedia.html.template
+++ b/templates/bookSocialMedia.html.template
@@ -1,6 +1,6 @@
 <ul>
   <li>
-    <a href="#">
+    <a href="https://twitter.com/intent/tweet?text=Check out {{title}} on Subway Library&url=https://subwaylibrary.nyc{{url}}&via=nypl" target="_blank">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" viewBox="0 0 500 500" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="share-on-twitter" class="twitter-icon">
       <title id="share-on-twitter">Share on Twitter</title>
       <path d="M250,0C111.9,0,0,111.9,0,250s111.9,250,250,250s250-111.9,250-250S388.1,0,250,0z M341.5,202.3
@@ -13,7 +13,7 @@
     </a>
   </li>
   <li>
-    <a href="#">
+    <a href="https://www.facebook.com/sharer/sharer.php?u=https://subwaylibrary.nyc{{url}}&display=popup" target="_blank">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="brooklyn-public-library-logo" class="fb-icon">
         <title id="share-on-face-book">Share on Face Book</title>
         <path d="M250,0C111.9,0,0,111.9,0,250s111.9,250,250,250s250-111.9,250-250S388.1,0,250,0z M296,245h-31v97l-39.9-0.2
@@ -22,7 +22,8 @@
     </a>
   </li>
   <li>
-    <a href="#">
+    <a href="mailto:?subject=Check out this title on Subway Library&amp;body=Read books, excerpts, and short stories from NYC public libraries.
+      Currently reading {{title}} by {{author}} on <a href='https://subwaylibrary.org{{url}}'>Subway Library</a>.">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="email" class="email-icon">
       <title id="email">Email</title>
       <path  d="M250,0C111.9,0,0,111.9,0,250s111.9,250,250,250s250-111.9,250-250S388.1,0,250,0z M349.8,325.9L150,326V222

--- a/templates/footerSocialMedia.html.template
+++ b/templates/footerSocialMedia.html.template
@@ -2,7 +2,7 @@
   <h2>Share Subway Library</h2>
   <ul>
     <li>
-      <a href="#">
+      <a href="https://twitter.com/intent/tweet?text=Read books, excerpts, and short stories from NYC public libraries&url=https://subwaylibrary.nyc&via=nypl" target="_blank">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" viewBox="0 0 500 500" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="share-on-twitter" class="twitter-icon">
         <title id="share-on-twitter">Share on Twitter</title>
         <path d="M250,0C111.9,0,0,111.9,0,250s111.9,250,250,250s250-111.9,250-250S388.1,0,250,0z M341.5,202.3
@@ -15,7 +15,7 @@
       </a>
     </li>
     <li>
-      <a href="#">
+      <a href="https://www.facebook.com/sharer/sharer.php?u=https://subwaylibrary.nyc&display=popup" target="_blank">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="brooklyn-public-library-logo" class="fb-icon">
           <title id="share-on-face-book">Share on Face Book</title>
           <path d="M250,0C111.9,0,0,111.9,0,250s111.9,250,250,250s250-111.9,250-250S388.1,0,250,0z M296,245h-31v97l-39.9-0.2
@@ -24,7 +24,7 @@
       </a>
     </li>
     <li>
-      <a href="#">
+      <a href="mailto:?subject=Check out Subway Library&amp;body=Read books, excerpts, and short stories from NYC public libraries.">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="email" class="email-icon">
         <title id="email">Email</title>
         <path  d="M250,0C111.9,0,0,111.9,0,250s111.9,250,250,250s250-111.9,250-250S388.1,0,250,0z M349.8,325.9L150,326V222


### PR DESCRIPTION
This fixes:
#52 - updating the NYPL, Bk, and Qns app links.
#49 - linking to social media and email. **Note** - This is a first pass which works, but still waiting on final copy and a better Twitter handle. I want to have it up on prod so we can test the pages on FB's [OG tag](https://developers.facebook.com/tools/debug/#_=_) checker. It'd be nice if we can test against the actual domain but that's fine for now.

Also added:
* OG and Twitter meta tags so the social media sharing looks good. 
* Updating style for each lane row based on @mgiraldo 's and @ricardoom 's feedback.
